### PR TITLE
Fix force-adding a second Navigator keybind

### DIFF
--- a/src/tk/wurst_client/files/FileManager.java
+++ b/src/tk/wurst_client/files/FileManager.java
@@ -248,7 +248,9 @@ public class FileManager
 			}
 			
 			// force-add GUI keybind if missing
-			if(!WurstClient.INSTANCE.keybinds.containsValue(".t navigator"))
+			TreeSet<String> navigator_keybind = new TreeSet<String>();
+			navigator_keybind.add(".t navigator");
+			if(!WurstClient.INSTANCE.keybinds.containsValue(navigator_keybind))
 			{
 				WurstClient.INSTANCE.keybinds.put("LCONTROL", ".t navigator");
 				needsUpdate = true;


### PR DESCRIPTION
Seems to fix #41: Don't force-add(#12) a second Navigator keybind.
You cannot test for a String value in a `TreeMap<String,TreeSet<String>>` - Now it
tests for a temporary TreeSet containing the String.

Signed-off-by: CisBetter CisBetter@users.noreply.github.com
