### PR TITLE
Fix #43: Check whether the mouse is above the OK-Button

### DIFF
--- a/src/tk/wurst_client/navigator/gui/NavigatorNewKeybindScreen.java
+++ b/src/tk/wurst_client/navigator/gui/NavigatorNewKeybindScreen.java
@@ -191,7 +191,7 @@ public class NavigatorNewKeybindScreen extends NavigatorScreen
 				int y2 = y1 + 20;
 				
 				// color
-				if(mouseX >= x1 && mouseX <= x2 && mouseY >= y1 && mouseY <= y2)
+				if(mouseX >= x1 && mouseX <= x2 && mouseY >= y1 && mouseY <= y2 && mouseY <= okButton.yPosition - 5)
 				{
 					hoveredCommand = i;
 					if(i == selectedCommand)


### PR DESCRIPTION
Users were able to click buttons that were hidden (outside of the
scrolled window). Wurst now checks whether the cursor is above the "OK"
button before setting hoveredCommand and updating the colour. Therefore
clicking "OK" won't select another keybindCommand. (This should fix
every Mod's keybind-adding if there are a lot of keybindCommands)

Signed-off-by: CisBetter CisBetter@users.noreply.github.com
