### PR TITLE
Feature: NoOverlay

### DIFF
--- a/patch/minecraft.patch
+++ b/patch/minecraft.patch
@@ -1,6 +1,6 @@
-From ac365aab1be1e842c323ebd676fcf3c89e2c5805 Mon Sep 17 00:00:00 2001
-From: Alexander01998 <contact.wurstimperium@gmail.com>
-Date: Tue, 1 Nov 2016 16:08:18 +0100
+From e64cb9fd82248c44012b2d6e193b6362268034db Mon Sep 17 00:00:00 2001
+From: CisBetter <CisBetter@users.noreply.github.com>
+Date: Wed, 2 Nov 2016 18:27:26 +0100
 Subject: [PATCH] mod
 
 ---
@@ -11,12 +11,12 @@ Subject: [PATCH] mod
  net/minecraft/block/BlockSlab.java                 |   6 +-
  net/minecraft/block/BlockSoulSand.java             |   6 +
  net/minecraft/client/Minecraft.java                | 223 +++++++++++----------
- net/minecraft/client/entity/EntityPlayerSP.java    | 146 ++++++++++++--
+ net/minecraft/client/entity/EntityPlayerSP.java    | 156 ++++++++++++--
  net/minecraft/client/gui/FontRenderer.java         |   2 +-
  net/minecraft/client/gui/GuiButton.java            |  14 +-
  net/minecraft/client/gui/GuiDisconnected.java      |  87 ++++++++
  net/minecraft/client/gui/GuiGameOver.java          |  14 +-
- net/minecraft/client/gui/GuiIngame.java            |  25 ++-
+ net/minecraft/client/gui/GuiIngame.java            |  31 ++-
  net/minecraft/client/gui/GuiIngameMenu.java        |  51 ++++-
  net/minecraft/client/gui/GuiMainMenu.java          |  23 ++-
  net/minecraft/client/gui/GuiMemoryErrorScreen.java |   4 +-
@@ -38,7 +38,8 @@ Subject: [PATCH] mod
  net/minecraft/client/particle/ParticleManager.java |   8 +-
  .../client/renderer/BlockFluidRenderer.java        |   8 +
  .../client/renderer/BlockModelRenderer.java        |  17 +-
- net/minecraft/client/renderer/EntityRenderer.java  |  57 +++++-
+ net/minecraft/client/renderer/EntityRenderer.java  |  82 ++++++--
+ net/minecraft/client/renderer/ItemRenderer.java    |  31 ++-
  net/minecraft/client/renderer/RenderGlobal.java    |   2 +-
  net/minecraft/client/renderer/RenderItem.java      |   8 +-
  net/minecraft/client/renderer/chunk/VisGraph.java  |   9 +-
@@ -74,10 +75,10 @@ Subject: [PATCH] mod
  net/minecraft/world/chunk/Chunk.java               |   2 +-
  .../world/gen/structure/MapGenStructure.java       |   6 +-
  net/minecraft/world/storage/WorldInfo.java         |  18 +-
- 70 files changed, 1285 insertions(+), 433 deletions(-)
+ 71 files changed, 1342 insertions(+), 448 deletions(-)
 
 diff --git a/net/minecraft/block/Block.java b/net/minecraft/block/Block.java
-index 25c6330..00426a2 100644
+index 25c6330..0edf33c 100644
 --- a/net/minecraft/block/Block.java
 +++ b/net/minecraft/block/Block.java
 @@ -1,10 +1,15 @@
@@ -99,7 +100,7 @@ index 25c6330..00426a2 100644
 @@ -370,7 +375,12 @@ public class Block
      @Deprecated
      public boolean isFullCube(IBlockState state)
- 	{
+     {
 -        return true;
 +		// TODO: Client
 +		if(WurstClient.INSTANCE.mods.xRayMod.isActive())
@@ -107,7 +108,7 @@ index 25c6330..00426a2 100644
 +		else
 +			return !WurstClient.INSTANCE.mods.freecamMod.isActive()
 +				&& !WurstClient.INSTANCE.mods.noClipMod.isActive();
- 	}
+     }
  
      public boolean isPassable(IBlockAccess worldIn, BlockPos pos)
 @@ -472,6 +482,10 @@ public class Block
@@ -180,7 +181,7 @@ index c2f89f3..c441aaa 100644
  
                  if (this.chestType == BlockChest.Type.BASIC)
 diff --git a/net/minecraft/block/BlockLiquid.java b/net/minecraft/block/BlockLiquid.java
-index c079ffc..ed8463f 100644
+index c079ffc..dbf0c6f 100644
 --- a/net/minecraft/block/BlockLiquid.java
 +++ b/net/minecraft/block/BlockLiquid.java
 @@ -1,7 +1,10 @@
@@ -197,12 +198,12 @@ index c079ffc..ed8463f 100644
 @@ -43,12 +46,16 @@ public abstract class BlockLiquid extends Block
      @Nullable
      public AxisAlignedBB getCollisionBoundingBox(IBlockState blockState, World worldIn, BlockPos pos)
- 	{
+     {
 -        return NULL_AABB;
 +		// TODO: Client
 +		return WurstClient.INSTANCE.mods.jesusMod.shouldBeSolid()
 +			? FULL_BLOCK_AABB : NULL_AABB;
- 	}
+     }
  
      public boolean isPassable(IBlockAccess worldIn, BlockPos pos)
      {
@@ -273,7 +274,7 @@ index 7b841d2..1930d3e 100644
          entityIn.motionZ *= 0.4D;
      }
 diff --git a/net/minecraft/client/Minecraft.java b/net/minecraft/client/Minecraft.java
-index ad84c84..0af1927 100644
+index ad84c84..e2cf354 100644
 --- a/net/minecraft/client/Minecraft.java
 +++ b/net/minecraft/client/Minecraft.java
 @@ -1,18 +1,5 @@
@@ -587,7 +588,7 @@ index ad84c84..0af1927 100644
 +		// TODO: Client
 +		if(this.currentScreen != null
 +			&& !WurstClient.INSTANCE.mods.menuWalkMod.shouldAllowWalking())
- 		{
+         {
 +			
              try
              {
@@ -618,7 +619,7 @@ index ad84c84..0af1927 100644
 +		// TODO: Client
 +		if(this.currentScreen == null || this.currentScreen.allowUserInput
 +			|| WurstClient.INSTANCE.mods.menuWalkMod.shouldAllowWalking())
- 		{
+         {
 +			
              this.mcProfiler.endStartSection("mouse");
              this.runTickMouse();
@@ -631,7 +632,7 @@ index ad84c84..0af1927 100644
 +			// TODO: Client
 +			if(!this.isGamePaused && this.theWorld != null
 +				&& !WurstClient.INSTANCE.mods.freecamMod.isActive())
- 			{
+             {
 +            	
                  this.theWorld.doVoidFogParticles(MathHelper.floor_double(this.thePlayer.posX), MathHelper.floor_double(this.thePlayer.posY), MathHelper.floor_double(this.thePlayer.posZ));
              }
@@ -772,7 +773,7 @@ index ad84c84..0af1927 100644
              public String call()
              {
 diff --git a/net/minecraft/client/entity/EntityPlayerSP.java b/net/minecraft/client/entity/EntityPlayerSP.java
-index 38f8c49..5864eae 100644
+index 38f8c49..91c7757 100644
 --- a/net/minecraft/client/entity/EntityPlayerSP.java
 +++ b/net/minecraft/client/entity/EntityPlayerSP.java
 @@ -1,7 +1,16 @@
@@ -850,7 +851,7 @@ index 38f8c49..5864eae 100644
          }
      }
  
-@@ -275,6 +292,22 @@ public class EntityPlayerSP extends AbstractClientPlayer
+@@ -275,24 +292,97 @@ public class EntityPlayerSP extends AbstractClientPlayer
  
          if (this.isCurrentViewEntity())
          {
@@ -873,7 +874,12 @@ index 38f8c49..5864eae 100644
              AxisAlignedBB axisalignedbb = this.getEntityBoundingBox();
              double d0 = this.posX - this.lastReportedPosX;
              double d1 = axisalignedbb.minY - this.lastReportedPosY;
-@@ -285,7 +318,64 @@ public class EntityPlayerSP extends AbstractClientPlayer
+             double d2 = this.posZ - this.lastReportedPosZ;
+-            double d3 = (double)(this.rotationYaw - this.lastReportedYaw);
+-            double d4 = (double)(this.rotationPitch - this.lastReportedPitch);
++            double d3 = (double)(yaw - this.lastReportedYaw);
++            double d4 = (double)(pitch - this.lastReportedPitch);
+             ++this.positionUpdateTicks;
              boolean flag2 = d0 * d0 + d1 * d1 + d2 * d2 > 9.0E-4D || this.positionUpdateTicks >= 20;
              boolean flag3 = d3 != 0.0D || d4 != 0.0D;
  
@@ -903,7 +909,8 @@ index 38f8c49..5864eae 100644
 +				{
 +					
 +				}else
-+				{
+ 				{
+-                this.connection.sendPacket(new CPacketPlayer.PositionRotation(this.motionX, -999.0D, this.motionZ, this.rotationYaw, this.rotationPitch, this.onGround));
 +					JesusMod jesusMod = WurstClient.INSTANCE.mods.jesusMod;
 +					jesusMod.time++;
 +					if(jesusMod.time >= jesusMod.delay)
@@ -936,9 +943,26 @@ index 38f8c49..5864eae 100644
 +					}
 +				}
 +			}else if (this.isRiding())
-             {
-                 this.connection.sendPacket(new CPacketPlayer.PositionRotation(this.motionX, -999.0D, this.motionZ, this.rotationYaw, this.rotationPitch, this.onGround));
++            {
++                this.connection.sendPacket(new CPacketPlayer.PositionRotation(this.motionX, -999.0D, this.motionZ, yaw, pitch, this.onGround));
                  flag2 = false;
+             }
+             else if (flag2 && flag3)
+             {
+-                this.connection.sendPacket(new CPacketPlayer.PositionRotation(this.posX, axisalignedbb.minY, this.posZ, this.rotationYaw, this.rotationPitch, this.onGround));
++                this.connection.sendPacket(new CPacketPlayer.PositionRotation(this.posX, axisalignedbb.minY, this.posZ, yaw, pitch, this.onGround));
+             }
+             else if (flag2)
+             {
+@@ -300,7 +390,7 @@ public class EntityPlayerSP extends AbstractClientPlayer
+             }
+             else if (flag3)
+             {
+-                this.connection.sendPacket(new CPacketPlayer.Rotation(this.rotationYaw, this.rotationPitch, this.onGround));
++                this.connection.sendPacket(new CPacketPlayer.Rotation(yaw, pitch, this.onGround));
+             }
+             else if (this.prevOnGround != this.onGround)
+             {
 @@ -322,7 +412,7 @@ public class EntityPlayerSP extends AbstractClientPlayer
              }
  
@@ -986,12 +1010,12 @@ index 38f8c49..5864eae 100644
  
 -    public boolean func_189809_N()
 +    public boolean isAutoJumpEnabled()
- 	{
+     {
 -        return this.field_189811_cr;
 +		// TODO: Client
 +		return this.autoJumpEnabled
 +			&& !WurstClient.INSTANCE.mods.stepMod.isActive();
- 	}
+     }
  
      protected void func_189810_i(float p_189810_1_, float p_189810_2_)
      {
@@ -1039,7 +1063,7 @@ index 93eccc5..9ee0d1c 100644
              int j = 14737632;
  
 diff --git a/net/minecraft/client/gui/GuiDisconnected.java b/net/minecraft/client/gui/GuiDisconnected.java
-index 76b8b3d..74486d8 100644
+index 76b8b3d..6bae32b 100644
 --- a/net/minecraft/client/gui/GuiDisconnected.java
 +++ b/net/minecraft/client/gui/GuiDisconnected.java
 @@ -2,6 +2,11 @@ package net.minecraft.client.gui;
@@ -1130,7 +1154,7 @@ index 76b8b3d..74486d8 100644
 +		{
 +			((GuiButton)this.buttonList.get(2)).displayString = "AutoReconnect";
 +		}
- 	}
+     }
  
      /**
 @@ -48,6 +113,28 @@ public class GuiDisconnected extends GuiScreen
@@ -1159,7 +1183,7 @@ index 76b8b3d..74486d8 100644
 +			servers.serverListSelector
 +				.updateOnlineServers(servers.savedServerList);
 +			mc.displayGuiScreen(servers);
- 		}
+         }
      }
  
 diff --git a/net/minecraft/client/gui/GuiGameOver.java b/net/minecraft/client/gui/GuiGameOver.java
@@ -1215,10 +1239,10 @@ index 3d3a010..249f603 100644
      }
  }
 diff --git a/net/minecraft/client/gui/GuiIngame.java b/net/minecraft/client/gui/GuiIngame.java
-index a623c57..b3ddf3c 100644
+index a623c57..56558d3 100644
 --- a/net/minecraft/client/gui/GuiIngame.java
 +++ b/net/minecraft/client/gui/GuiIngame.java
-@@ -4,10 +4,16 @@ import com.google.common.base.Predicate;
+@@ -4,10 +4,17 @@ import com.google.common.base.Predicate;
  import com.google.common.collect.Iterables;
  import com.google.common.collect.Lists;
  import com.google.common.collect.Ordering;
@@ -1230,12 +1254,25 @@ index a623c57..b3ddf3c 100644
 +
  import javax.annotation.Nullable;
 +
++import tk.wurst_client.WurstClient;
 +import tk.wurst_client.gui.UIRenderer;
 +import tk.wurst_client.mods.ArenaBrawlMod;
  import net.minecraft.block.material.Material;
  import net.minecraft.client.Minecraft;
  import net.minecraft.client.gui.inventory.GuiContainer;
-@@ -342,10 +348,13 @@ public class GuiIngame extends Gui
+@@ -155,7 +162,10 @@ public class GuiIngame extends Gui
+ 
+         ItemStack itemstack = this.mc.thePlayer.inventory.armorItemInSlot(3);
+ 
+-        if (this.mc.gameSettings.thirdPersonView == 0 && itemstack != null && itemstack.getItem() == Item.getItemFromBlock(Blocks.PUMPKIN))
++        // TODO: Client
++		if(this.mc.gameSettings.thirdPersonView == 0 && itemstack != null
++			&& itemstack.getItem() == Item.getItemFromBlock(Blocks.PUMPKIN)
++			&& !WurstClient.INSTANCE.mods.noOverlayMod.isEnabled())
+         {
+             this.renderPumpkinOverlay(scaledresolution);
+         }
+@@ -342,10 +352,13 @@ public class GuiIngame extends Gui
  
          ScoreObjective scoreobjective1 = scoreobjective != null ? scoreobjective : scoreboard.getObjectiveInDisplaySlot(1);
  
@@ -1243,7 +1280,7 @@ index a623c57..b3ddf3c 100644
 -        {
 +		// TODO: Client
 +		if(scoreobjective1 != null)
- 			this.renderScoreboard(scoreobjective1, scaledresolution);
+             this.renderScoreboard(scoreobjective1, scaledresolution);
 -        }
 +		else
 +			ArenaBrawlMod.scoreboard = null;
@@ -1252,7 +1289,7 @@ index a623c57..b3ddf3c 100644
  
          GlStateManager.enableBlend();
          GlStateManager.tryBlendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
-@@ -726,11 +735,18 @@ public class GuiIngame extends Gui
+@@ -726,11 +739,18 @@ public class GuiIngame extends Gui
          int l1 = scaledRes.getScaledWidth() - i - 3;
          int j = 0;
  
@@ -1271,7 +1308,7 @@ index a623c57..b3ddf3c 100644
              String s2 = TextFormatting.RED + "" + score1.getScorePoints();
              int k = j1 - j * this.getFontRenderer().FONT_HEIGHT;
              int l = scaledRes.getScaledWidth() - 3 + 2;
-@@ -746,6 +762,9 @@ public class GuiIngame extends Gui
+@@ -746,6 +766,9 @@ public class GuiIngame extends Gui
                  this.getFontRenderer().drawString(s3, l1 + i / 2 - this.getFontRenderer().getStringWidth(s3) / 2, k - this.getFontRenderer().FONT_HEIGHT, 553648127);
              }
          }
@@ -1389,7 +1426,7 @@ index 7dec74c..b7327fa 100644
      }
  }
 diff --git a/net/minecraft/client/gui/GuiMainMenu.java b/net/minecraft/client/gui/GuiMainMenu.java
-index 2249b2b..29e56a2 100644
+index 2249b2b..c5edc29 100644
 --- a/net/minecraft/client/gui/GuiMainMenu.java
 +++ b/net/minecraft/client/gui/GuiMainMenu.java
 @@ -1,6 +1,7 @@
@@ -1443,7 +1480,7 @@ index 2249b2b..29e56a2 100644
 +		}else if(calendar.get(2) + 1 == 2 && calendar.get(5) == 9)
 +		{
 +			this.splashText = "Happy birthday, Alexander01998!";
- 		}
+         }
 +		ServerHook.setCurrentIpToSingleplayer();
  
          int i = 24;
@@ -1496,7 +1533,7 @@ index 27d32e9..4f611eb 100644
          else if (button.id == 1)
          {
 diff --git a/net/minecraft/client/gui/GuiMultiplayer.java b/net/minecraft/client/gui/GuiMultiplayer.java
-index 47c0f09..44de603 100644
+index 47c0f09..4d97728 100644
 --- a/net/minecraft/client/gui/GuiMultiplayer.java
 +++ b/net/minecraft/client/gui/GuiMultiplayer.java
 @@ -2,8 +2,10 @@ package net.minecraft.client.gui;
@@ -1556,7 +1593,7 @@ index 47c0f09..44de603 100644
 +        
 +		// TODO: Client
 +		if(serverListSelector != null)
- 			this.serverListSelector.handleMouseInput();
+         this.serverListSelector.handleMouseInput();
      }
  
 @@ -99,6 +116,21 @@ public class GuiMultiplayer extends GuiScreen implements GuiYesNoCallback
@@ -1723,7 +1760,7 @@ index 742557f..db75287 100644
          LOGGER.info("[CHAT] {}", new Object[] {NEWLINE_STRING_JOINER.join(NEWLINE_SPLITTER.split(chatComponent.getUnformattedText()))});
      }
 diff --git a/net/minecraft/client/gui/GuiScreenBook.java b/net/minecraft/client/gui/GuiScreenBook.java
-index 7428bc1..d7a9a86 100644
+index 7428bc1..47d23ab 100644
 --- a/net/minecraft/client/gui/GuiScreenBook.java
 +++ b/net/minecraft/client/gui/GuiScreenBook.java
 @@ -2,10 +2,14 @@ package net.minecraft.client.gui;
@@ -1839,7 +1876,7 @@ index 7428bc1..d7a9a86 100644
 +			}else if(button.id == 6)
 +			{
 +				mc.displayGuiScreen(new GuiBookHack(this));
- 			}
+             }
  
              this.updateButtons();
          }
@@ -2655,7 +2692,7 @@ index 896e3d6..3b3294b 100644
          TextureAtlasSprite[] atextureatlassprite = flag ? this.atlasSpritesLava : this.atlasSpritesWater;
          int i = this.blockColors.colorMultiplier(blockStateIn, blockAccess, blockPosIn, 0);
 diff --git a/net/minecraft/client/renderer/BlockModelRenderer.java b/net/minecraft/client/renderer/BlockModelRenderer.java
-index 30f9818..50c52ac 100644
+index 30f9818..f3b9d65 100644
 --- a/net/minecraft/client/renderer/BlockModelRenderer.java
 +++ b/net/minecraft/client/renderer/BlockModelRenderer.java
 @@ -2,7 +2,11 @@ package net.minecraft.client.renderer;
@@ -2691,15 +2728,15 @@ index 30f9818..50c52ac 100644
 +		if(!list1.isEmpty()
 +			&& (!WurstClient.INSTANCE.mods.xRayMod.isActive() || XRayUtils
 +				.isXRayBlock(stateIn.getBlock())))
- 		{
+         {
 -            this.renderQuadsSmooth(worldIn, stateIn, posIn, buffer, list1, afloat, bitset, blockmodelrenderer$ambientocclusionface);
 +			this.renderQuadsSmooth(worldIn, stateIn, posIn, buffer, list1,
 +				afloat, bitset, blockmodelrenderer$ambientocclusionface);
- 			flag = true;
- 		}
+             flag = true;
+         }
  
 diff --git a/net/minecraft/client/renderer/EntityRenderer.java b/net/minecraft/client/renderer/EntityRenderer.java
-index 25e1fb8..4f66d6c 100644
+index 25e1fb8..6370c17 100644
 --- a/net/minecraft/client/renderer/EntityRenderer.java
 +++ b/net/minecraft/client/renderer/EntityRenderer.java
 @@ -3,6 +3,7 @@ package net.minecraft.client.renderer;
@@ -2793,16 +2830,16 @@ index 25e1fb8..4f66d6c 100644
 +		// TODO: Client
 +		if(this.mc.gameSettings.viewBobbing
 +			&& !WurstClient.INSTANCE.mods.tracersMod.isActive())
- 		{
- 			this.setupViewBobbing(partialTicks);
- 		}
+         {
+             this.setupViewBobbing(partialTicks);
+         }
  
          float f1 = this.mc.thePlayer.prevTimeInPortal + (this.mc.thePlayer.timeInPortal - this.mc.thePlayer.prevTimeInPortal) * partialTicks;
  
 -        if (f1 > 0.0F)
 +		// TODO: Client
 +		if(f1 > 0.0F && !WurstClient.INSTANCE.mods.antiBlindMod.isActive())
- 		{
+         {
 +			
              int i = 20;
  
@@ -2839,7 +2876,7 @@ index 25e1fb8..4f66d6c 100644
 +		
 +		// TODO: Client
 +		if(!WurstClient.INSTANCE.mods.caveFinderMod.isActive())
- 			GlStateManager.enableDepth();
+         GlStateManager.enableDepth();
 +		
          GlStateManager.enableAlpha();
          GlStateManager.alphaFunc(516, 0.5F);
@@ -2854,6 +2891,15 @@ index 25e1fb8..4f66d6c 100644
          if (this.renderHand)
          {
              GlStateManager.clear(256);
+@@ -1824,7 +1851,7 @@ public class EntityRenderer implements IResourceManagerReloadListener
+             this.fogColorGreen = (float)vec3d3.yCoord;
+             this.fogColorBlue = (float)vec3d3.zCoord;
+         }
+-        else if (iblockstate.getMaterial() == Material.WATER)
++		else if(iblockstate.getMaterial() == Material.WATER)
+         {
+             float f12 = 0.0F;
+ 
 @@ -1855,8 +1882,12 @@ public class EntityRenderer implements IResourceManagerReloadListener
          this.fogColorBlue *= f13;
          double d1 = (entity.lastTickPosY + (entity.posY - entity.lastTickPosY) * (double)partialTicks) * world.provider.getVoidFogYFactor();
@@ -2863,7 +2909,7 @@ index 25e1fb8..4f66d6c 100644
 +		if(entity instanceof EntityLivingBase
 +			&& ((EntityLivingBase)entity).isPotionActive(MobEffects.BLINDNESS)
 +			&& !WurstClient.INSTANCE.mods.antiBlindMod.isActive())
- 		{
+         {
 +			
              int i = ((EntityLivingBase)entity).getActivePotionEffect(MobEffects.BLINDNESS).getDuration();
  
@@ -2877,11 +2923,130 @@ index 25e1fb8..4f66d6c 100644
 +		if(entity instanceof EntityLivingBase
 +			&& ((EntityLivingBase)entity).isPotionActive(MobEffects.BLINDNESS)
 +			&& !WurstClient.INSTANCE.mods.antiBlindMod.isActive())
- 		{
+         {
 +			
              float f1 = 5.0F;
              int i = ((EntityLivingBase)entity).getActivePotionEffect(MobEffects.BLINDNESS).getDuration();
  
+@@ -1974,13 +2009,24 @@ public class EntityRenderer implements IResourceManagerReloadListener
+ 
+             if (entity instanceof EntityLivingBase)
+             {
+-                if (((EntityLivingBase)entity).isPotionActive(MobEffects.WATER_BREATHING))
++            	// TODO: Client
++                if(WurstClient.INSTANCE.mods.noOverlayMod.isEnabled())
+                 {
++                	// We need at least a little bit fog to hide the black horizon
+                     GlStateManager.setFogDensity(0.01F);
+                 }
+                 else
+                 {
+-                    GlStateManager.setFogDensity(0.1F - (float)EnchantmentHelper.getRespirationModifier((EntityLivingBase)entity) * 0.03F);
++					if(((EntityLivingBase)entity)
++						.isPotionActive(MobEffects.WATER_BREATHING))
++					{
++						GlStateManager.setFogDensity(0.01F);
++					}else
++					{
++						GlStateManager.setFogDensity(0.1F
++							- (float)EnchantmentHelper.getRespirationModifier(
++								(EntityLivingBase)entity) * 0.03F);
++					}                	
+                 }
+             }
+             else
+@@ -1990,9 +2036,17 @@ public class EntityRenderer implements IResourceManagerReloadListener
+         }
+         else if (iblockstate.getMaterial() == Material.LAVA)
+         {
++        	// TODO: Client
++        	if(WurstClient.INSTANCE.mods.noOverlayMod.isEnabled())
++        	{
++        		GlStateManager.setFogDensity(0.1F);
++        	}
++        	else
++        	{
+             GlStateManager.setFog(GlStateManager.FogMode.EXP);
+             GlStateManager.setFogDensity(2.0F);
+         }
++        }
+         else
+         {
+             float f = this.farPlaneDistance;
+diff --git a/net/minecraft/client/renderer/ItemRenderer.java b/net/minecraft/client/renderer/ItemRenderer.java
+index 2619f50..eaff596 100644
+--- a/net/minecraft/client/renderer/ItemRenderer.java
++++ b/net/minecraft/client/renderer/ItemRenderer.java
+@@ -28,6 +28,7 @@ import net.minecraft.util.ResourceLocation;
+ import net.minecraft.util.math.BlockPos;
+ import net.minecraft.util.math.MathHelper;
+ import net.minecraft.world.storage.MapData;
++import tk.wurst_client.WurstClient;
+ 
+ public class ItemRenderer
+ {
+@@ -491,7 +492,9 @@ public class ItemRenderer
+                 this.renderWaterOverlayTexture(partialTicks);
+             }
+ 
+-            if (this.mc.thePlayer.isBurning())
++             // TODO: Client
++			if(this.mc.thePlayer.isBurning()
++				&& !WurstClient.INSTANCE.mods.noOverlayMod.isEnabled())
+             {
+                 this.renderFireInFirstPerson(partialTicks);
+             }
+@@ -536,13 +539,24 @@ public class ItemRenderer
+      */
+     private void renderWaterOverlayTexture(float partialTicks)
+     {
++    	// TODO: Client
++        if(WurstClient.INSTANCE.mods.noOverlayMod.isEnabled())
++		{
++        	// nothing
++		}
++        else
++        {
+         this.mc.getTextureManager().bindTexture(RES_UNDERWATER_OVERLAY);
+         Tessellator tessellator = Tessellator.getInstance();
+         VertexBuffer vertexbuffer = tessellator.getBuffer();
+         float f = this.mc.thePlayer.getBrightness(partialTicks);
+         GlStateManager.color(f, f, f, 0.5F);
+         GlStateManager.enableBlend();
+-        GlStateManager.tryBlendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
++			GlStateManager.tryBlendFuncSeparate(
++				GlStateManager.SourceFactor.SRC_ALPHA,
++				GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
++				GlStateManager.SourceFactor.ONE,
++				GlStateManager.DestFactor.ZERO);
+         GlStateManager.pushMatrix();
+         float f1 = 4.0F;
+         float f2 = -1.0F;
+@@ -553,15 +567,20 @@ public class ItemRenderer
+         float f7 = -this.mc.thePlayer.rotationYaw / 64.0F;
+         float f8 = this.mc.thePlayer.rotationPitch / 64.0F;
+         vertexbuffer.begin(7, DefaultVertexFormats.POSITION_TEX);
+-        vertexbuffer.pos(-1.0D, -1.0D, -0.5D).tex((double)(4.0F + f7), (double)(4.0F + f8)).endVertex();
+-        vertexbuffer.pos(1.0D, -1.0D, -0.5D).tex((double)(0.0F + f7), (double)(4.0F + f8)).endVertex();
+-        vertexbuffer.pos(1.0D, 1.0D, -0.5D).tex((double)(0.0F + f7), (double)(0.0F + f8)).endVertex();
+-        vertexbuffer.pos(-1.0D, 1.0D, -0.5D).tex((double)(4.0F + f7), (double)(0.0F + f8)).endVertex();
++			vertexbuffer.pos(-1.0D, -1.0D, -0.5D)
++				.tex((double)(4.0F + f7), (double)(4.0F + f8)).endVertex();
++			vertexbuffer.pos(1.0D, -1.0D, -0.5D)
++				.tex((double)(0.0F + f7), (double)(4.0F + f8)).endVertex();
++			vertexbuffer.pos(1.0D, 1.0D, -0.5D)
++				.tex((double)(0.0F + f7), (double)(0.0F + f8)).endVertex();
++			vertexbuffer.pos(-1.0D, 1.0D, -0.5D)
++				.tex((double)(4.0F + f7), (double)(0.0F + f8)).endVertex();
+         tessellator.draw();
+         GlStateManager.popMatrix();
+         GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+         GlStateManager.disableBlend();
+     }
++    }
+ 
+     /**
+      * Renders the fire on the screen for first person mode. Arg: partialTickTime
 diff --git a/net/minecraft/client/renderer/RenderGlobal.java b/net/minecraft/client/renderer/RenderGlobal.java
 index 7e4283f..4b8b209 100644
 --- a/net/minecraft/client/renderer/RenderGlobal.java
@@ -2933,7 +3098,7 @@ index 0ed8384..fd86a4f 100644
                      public String call() throws Exception
                      {
 diff --git a/net/minecraft/client/renderer/chunk/VisGraph.java b/net/minecraft/client/renderer/chunk/VisGraph.java
-index 342c491..353d716 100644
+index 342c491..215db5e 100644
 --- a/net/minecraft/client/renderer/chunk/VisGraph.java
 +++ b/net/minecraft/client/renderer/chunk/VisGraph.java
 @@ -1,13 +1,16 @@
@@ -2962,7 +3127,7 @@ index 342c491..353d716 100644
 +		if(WurstClient.INSTANCE.mods.xRayMod.isActive())
 +			return;
 +    	
- 		this.bitSet.set(getIndex(pos), true);
+         this.bitSet.set(getIndex(pos), true);
          --this.empty;
      }
 diff --git a/net/minecraft/client/renderer/entity/Render.java b/net/minecraft/client/renderer/entity/Render.java
@@ -3513,7 +3678,7 @@ index 40eb661..7e81b8b 100644
              public String call() throws Exception
              {
 diff --git a/net/minecraft/entity/EntityLivingBase.java b/net/minecraft/entity/EntityLivingBase.java
-index 24a6e35..28d494e 100644
+index 24a6e35..01dc101 100644
 --- a/net/minecraft/entity/EntityLivingBase.java
 +++ b/net/minecraft/entity/EntityLivingBase.java
 @@ -2,13 +2,18 @@ package net.minecraft.entity;
@@ -3559,7 +3724,7 @@ index 24a6e35..28d494e 100644
 +				|| WurstClient.INSTANCE.mods.noSlowdownMod.isActive()
 +				|| this instanceof EntityPlayer
 +				&& ((EntityPlayer)this).capabilities.isFlying)
- 			{
+             {
 +				
                  if (!this.isInLava() || this instanceof EntityPlayer && ((EntityPlayer)this).capabilities.isFlying)
                  {
@@ -3778,7 +3943,7 @@ index cfa538d..2e4d80f 100644
                                      public String call() throws Exception
                                      {
 diff --git a/net/minecraft/network/play/server/SPacketJoinGame.java b/net/minecraft/network/play/server/SPacketJoinGame.java
-index 46422e0..c2778e2 100644
+index 46422e0..23fcf49 100644
 --- a/net/minecraft/network/play/server/SPacketJoinGame.java
 +++ b/net/minecraft/network/play/server/SPacketJoinGame.java
 @@ -1,6 +1,8 @@
@@ -3961,7 +4126,7 @@ index 078063f..2de9183 100644
          long j = i - this.lastSyncSysClock;
          long k = System.nanoTime() / 1000000L;
 diff --git a/net/minecraft/util/text/TextComponentBase.java b/net/minecraft/util/text/TextComponentBase.java
-index fb72270..5ef6ca9 100644
+index fb72270..4b7fcc9 100644
 --- a/net/minecraft/util/text/TextComponentBase.java
 +++ b/net/minecraft/util/text/TextComponentBase.java
 @@ -3,6 +3,8 @@ package net.minecraft.util.text;
@@ -3979,7 +4144,7 @@ index fb72270..5ef6ca9 100644
  
 -        for (ITextComponent itextcomponent : this)
 +		try
- 		{
+         {
 -            stringbuilder.append(itextcomponent.getStyle().getFormattingCode());
 -            stringbuilder.append(itextcomponent.getUnformattedComponentText());
 +			for(ITextComponent itextcomponent : this)
@@ -3988,8 +4153,8 @@ index fb72270..5ef6ca9 100644
 +					.append(itextcomponent.getStyle().getFormattingCode());
 +				stringbuilder
 +					.append(itextcomponent.getUnformattedComponentText());
- 				stringbuilder.append((Object)TextFormatting.RESET);
- 			}
+             stringbuilder.append((Object)TextFormatting.RESET);
+         }
 +		}catch(ConcurrentModificationException e)
 +		{
 +			e.printStackTrace();
@@ -3999,7 +4164,7 @@ index fb72270..5ef6ca9 100644
          return stringbuilder.toString();
      }
 diff --git a/net/minecraft/world/World.java b/net/minecraft/world/World.java
-index 69679f6..316eb71 100644
+index 69679f6..d40bb0d 100644
 --- a/net/minecraft/world/World.java
 +++ b/net/minecraft/world/World.java
 @@ -1,16 +1,19 @@
@@ -4097,8 +4262,8 @@ index 69679f6..316eb71 100644
 +				.getValue();
 +		}else
 +		{
- 			return this.provider.getMoonPhase(this.worldInfo.getWorldTime());
- 		}
+         return this.provider.getMoonPhase(this.worldInfo.getWorldTime());
+     }
 +    }
  
      /**
@@ -4260,5 +4425,5 @@ index c326563..ebfd40d 100644
              public String call() throws Exception
              {
 -- 
-2.0.0
+2.10.1.windows.1
 

--- a/src/tk/wurst_client/mods/ModManager.java
+++ b/src/tk/wurst_client/mods/ModManager.java
@@ -110,6 +110,7 @@ public class ModManager
 	public final NoClipMod noClipMod = new NoClipMod();
 	public final NoFallMod noFallMod = new NoFallMod();
 	public final NoHurtcamMod noHurtcamMod = new NoHurtcamMod();
+	public final NoOverlayMod noOverlayMod = new NoOverlayMod();
 	public final NoSlowdownMod noSlowdownMod = new NoSlowdownMod();
 	public final NoWallsMod noWallsMod = new NoWallsMod();
 	public final NoWeatherMod noWeatherMod = new NoWeatherMod();

--- a/src/tk/wurst_client/mods/NoOverlayMod.java
+++ b/src/tk/wurst_client/mods/NoOverlayMod.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2014 - 2016 | Wurst-Imperium | All rights reserved.
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package tk.wurst_client.mods;
+
+import tk.wurst_client.mods.Mod.Category;
+
+@Mod.Info(category = Category.RENDER,
+	description = "Blocks the overlays of pumpkins, water, fire, and lava.",
+	name = "NoOverlay",
+	tags = "AntiPumkin, no overlay")
+@Mod.Bypasses
+public class NoOverlayMod extends Mod
+{
+}


### PR DESCRIPTION
NoOverlay blocks the overlays of pumpkins, water, fire, and lava
(standard in modern clients). If Wurst already contains this mod let me
know :smile:
## Some screen shots (all with a pumpkin on the head):

**underwater**
![2016-10-26_20 20 21](https://cloud.githubusercontent.com/assets/17952058/19740391/d7fc62ea-9bbe-11e6-8d1e-a937f350472d.png)
**in lava**
![2016-10-26_20 22 08](https://cloud.githubusercontent.com/assets/17952058/19740403/dde0eb40-9bbe-11e6-9c62-c82d32c81b65.png)
**standing in fire**
![2016-10-26_20 22 56](https://cloud.githubusercontent.com/assets/17952058/19740410/e1146dc8-9bbe-11e6-967d-fca060e40155.png)

Signed-off-by: CisBetter CisBetter@users.noreply.github.com
