### PR TITLE
Fix ParkourMod jumping in water

### DIFF
--- a/src/tk/wurst_client/mods/ParkourMod.java
+++ b/src/tk/wurst_client/mods/ParkourMod.java
@@ -30,6 +30,8 @@ public class ParkourMod extends Mod implements UpdateListener
 		if(mc.thePlayer.onGround && !mc.thePlayer.isSneaking()
 			&& !mc.gameSettings.keyBindSneak.pressed
 			&& !mc.gameSettings.keyBindJump.pressed
+			&& !mc.thePlayer.isInWater()
+			&& !mc.thePlayer.isInLava()
 			&& mc.theWorld.getCollisionBoxes(mc.thePlayer,
 				mc.thePlayer.getEntityBoundingBox().offset(0, -0.5, 0)
 					.expand(-0.001, 0, -0.001))


### PR DESCRIPTION
Jumping in water was detected as `flying` by (almost) every AntiCheat.
Now ParkourMod checks whether the player is not in water or lava before jumping.

Signed-off-by: CisBetter <CisBetter@users.noreply.github.com>