### PR TITLE
Set project specific text file encoding

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=ISO-8859-1


### PR DESCRIPTION
Added org.eclipse.core.resources.prefs in .settings - The new encoding
is `ISO-8859-1`. This should fix problems with text file encoding and
the copyright sign.