### PR TITLE
Add ability to eat the least available food first

### DIFF
--- a/src/tk/wurst_client/mods/AutoEatMod.java
+++ b/src/tk/wurst_client/mods/AutoEatMod.java
@@ -67,14 +67,11 @@ public class AutoEatMod extends Mod implements UpdateListener
 		for(int i = 0; i < 9; i++)
 		{
 			ItemStack item = mc.thePlayer.inventory.getStackInSlot(i);
-			if(item == null)
+			if(item == null || !(item.getItem() instanceof ItemFood))
 				continue;
-			float saturation = 0;
-			if(item.getItem() instanceof ItemFood)
-				saturation =
-					((ItemFood)item.getItem()).getSaturationModifier(item);
-			if(useLowestSaturation
-				? saturation < bestSaturation && saturation != 0.0F
+			float saturation =
+				((ItemFood)item.getItem()).getSaturationModifier(item);
+			if(useLowestSaturation ? saturation < bestSaturation
 				: saturation > bestSaturation)
 			{
 				bestSaturation = saturation;

--- a/src/tk/wurst_client/mods/AutoEatMod.java
+++ b/src/tk/wurst_client/mods/AutoEatMod.java
@@ -73,21 +73,12 @@ public class AutoEatMod extends Mod implements UpdateListener
 			if(item.getItem() instanceof ItemFood)
 				saturation =
 					((ItemFood)item.getItem()).getSaturationModifier(item);
-			if(useLowestSaturation)
+			if(useLowestSaturation
+				? saturation < bestSaturation && saturation != 0.0F
+				: saturation > bestSaturation)
 			{
- 				if(saturation < bestSaturation && saturation != 0.0F)
-				{
-					bestSaturation = saturation;
-					bestSlot = i;
-				}
-			}
-			else
-			{
-				if(saturation > bestSaturation)
-				{
-					bestSaturation = saturation;
-					bestSlot = i;
-				}
+				bestSaturation = saturation;
+				bestSlot = i;
 			}
 		}
 		if(bestSlot == -1)

--- a/src/tk/wurst_client/mods/AutoEatMod.java
+++ b/src/tk/wurst_client/mods/AutoEatMod.java
@@ -14,6 +14,7 @@ import tk.wurst_client.events.listeners.UpdateListener;
 import tk.wurst_client.mods.Mod.Bypasses;
 import tk.wurst_client.mods.Mod.Info;
 import tk.wurst_client.navigator.NavigatorItem;
+import tk.wurst_client.navigator.settings.CheckboxSetting;
 
 @Info(
 	description = "Automatically eats food when necessary.",
@@ -25,6 +26,22 @@ public class AutoEatMod extends Mod implements UpdateListener
 {
 	private int oldSlot;
 	private int bestSlot;
+	public boolean useLowestSaturation;
+	
+	@Override
+	public void initSettings()
+	{
+		settings.add(new CheckboxSetting(
+			"Eat items that give low Food Points first (use to clean up your inventory)",
+			false)
+		{
+			@Override
+			public void update()
+			{
+				useLowestSaturation = isChecked();
+			}
+		});
+	}
 	
 	@Override
 	public NavigatorItem[] getSeeAlso()
@@ -45,7 +62,7 @@ public class AutoEatMod extends Mod implements UpdateListener
 		if(oldSlot != -1 || mc.thePlayer.capabilities.isCreativeMode
 			|| mc.thePlayer.getFoodStats().getFoodLevel() >= 20)
 			return;
-		float bestSaturation = 0F;
+		float bestSaturation = useLowestSaturation? 10F : 0F;
 		bestSlot = -1;
 		for(int i = 0; i < 9; i++)
 		{
@@ -56,10 +73,21 @@ public class AutoEatMod extends Mod implements UpdateListener
 			if(item.getItem() instanceof ItemFood)
 				saturation =
 					((ItemFood)item.getItem()).getSaturationModifier(item);
-			if(saturation > bestSaturation)
+			if(useLowestSaturation)
 			{
-				bestSaturation = saturation;
-				bestSlot = i;
+ 				if(saturation < bestSaturation && saturation != 0.0F)
+				{
+					bestSaturation = saturation;
+					bestSlot = i;
+				}
+			}
+			else
+			{
+				if(saturation > bestSaturation)
+				{
+					bestSaturation = saturation;
+					bestSlot = i;
+				}
 			}
 		}
 		if(bestSlot == -1)


### PR DESCRIPTION
As requested in #66 by @mmehnert:

> * eat the least available food would be nice to clear out inventory faster or
> 
>    * eat food with the smallest saturation instead of highest saturation and