### PR TITLE
Add a basic StashEsp

### DIFF
--- a/src/tk/wurst_client/mods/ChestEspMod.java
+++ b/src/tk/wurst_client/mods/ChestEspMod.java
@@ -41,7 +41,7 @@ public class ChestEspMod extends Mod implements RenderListener
 	@Override
 	public NavigatorItem[] getSeeAlso()
 	{
-		return new NavigatorItem[]{wurst.mods.itemEspMod, wurst.mods.searchMod,
+		return new NavigatorItem[]{wurst.mods.stashEspMod, wurst.mods.itemEspMod, wurst.mods.searchMod,
 			wurst.mods.xRayMod};
 	}
 	

--- a/src/tk/wurst_client/mods/ModManager.java
+++ b/src/tk/wurst_client/mods/ModManager.java
@@ -135,6 +135,7 @@ public class ModManager
 	public final SpeedHackMod speedHackMod = new SpeedHackMod();
 	public final SpeedNukerMod speedNukerMod = new SpeedNukerMod();
 	public final SpiderMod spiderMod = new SpiderMod();
+	public final StashEspMod stashEspMod = new StashEspMod();
 	public final StepMod stepMod = new StepMod();
 	public final ThrowMod throwMod = new ThrowMod();
 	public final TimerMod timerMod = new TimerMod();

--- a/src/tk/wurst_client/mods/StashEspMod.java
+++ b/src/tk/wurst_client/mods/StashEspMod.java
@@ -1,0 +1,63 @@
+package tk.wurst_client.mods;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityDispenser;
+import net.minecraft.tileentity.TileEntityFurnace;
+import net.minecraft.tileentity.TileEntityHopper;
+import tk.wurst_client.events.listeners.RenderListener;
+import tk.wurst_client.mods.Mod.Bypasses;
+import tk.wurst_client.mods.Mod.Category;
+import tk.wurst_client.mods.Mod.Info;
+import tk.wurst_client.navigator.NavigatorItem;
+import tk.wurst_client.navigator.settings.SliderSetting;
+import tk.wurst_client.utils.RenderUtils;
+
+@Info(
+        description = "Allows you to see hidden storage through walls.",
+        name = "StashESP",
+        tags = "StashFinder, stash esp, stash finder",
+        help = "Mods/StashESP")
+@Bypasses
+public class StashEspMod extends Mod implements RenderListener {
+
+    private int maxStashes = 1000;
+
+    @Override
+    public NavigatorItem[] getSeeAlso()
+    {
+        return new NavigatorItem[]{wurst.mods.chestEspMod, wurst.mods.itemEspMod, wurst.mods.searchMod,
+                wurst.mods.xRayMod};
+    }
+
+    @Override
+    public void onEnable()
+    {
+        wurst.events.add(RenderListener.class, this);
+    }
+
+    @Override
+    public void onRender() {
+        int stashes = 0;
+
+        for (int i = 0; i < mc.theWorld.loadedTileEntityList.size(); i++) {
+            TileEntity tileEntity = mc.theWorld.loadedTileEntityList.get(i);
+
+            if (stashes >= maxStashes)
+                break;
+
+            if (tileEntity instanceof TileEntityDispenser ||
+                    tileEntity instanceof TileEntityHopper ||
+                    tileEntity instanceof TileEntityFurnace) {
+                stashes++;
+                RenderUtils.blockEspFrame(tileEntity.getPos(), 1, 0.5, 0);
+                RenderUtils.blockEsp(tileEntity.getPos(), 1, 0.5, 0);
+            }
+        }
+    }
+
+    @Override
+    public void onDisable()
+    {
+        wurst.events.remove(RenderListener.class, this);
+    }
+}


### PR DESCRIPTION
StashEsp is based on ChestEsp.

It renders a box esp on storage items commonly used in hidden stashes (such as droppers, dispensers, hoppers and furnaces).

It could be extended to make each item optional, or even re-written as a generic tileentity esp where all tileentities can be toggled on or off, but I have submitted a basic version here for your feedback.

Please also feel free to suggest a different colour for the esp.